### PR TITLE
Fix build when using Zig 0.11.0

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -39,7 +39,7 @@ pub fn build(b: *std.Build) void {
     // This declares intent for the library to be installed into the standard
     // location when the user invokes the "install" step (the default step when
     // running `zig build`).
-    lib.install();
+    b.installArtifact(lib);
 
     // Creates a step for unit testing.
     const main_tests = b.addTest(.{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -3,7 +3,7 @@
     .version = "0.0.0",
     .dependencies = .{
         .zkwargs = .{
-            .url = "https://github.com/MadLittleMods/zkwargs/archive/ac419c94c81cb696017434e0f76c3e767b472ede.tar.gz",
+            .url = "https://github.com/hmusgrave/zkwargs/archive/4b23becf731ecaac1f29d629943d11b23c7802e8.tar.gz",
             .hash = "1220f6fd467fd42cd5ec98a360caacdcda9d3b9c3557fdcdef285cabbdee3c7c79dc",
         },
     },

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -3,8 +3,8 @@
     .version = "0.0.0",
     .dependencies = .{
         .zkwargs = .{
-	    .url = "https://github.com/hmusgrave/zkwargs/archive/refs/tags/z11-0.0.0.tar.gz",
-            .hash = "1220382447b50be7f14b48d17baf0286c1adb297f6edf4a4c00b008841c07cadb00a",
+            .url = "https://github.com/MadLittleMods/zkwargs/archive/ac419c94c81cb696017434e0f76c3e767b472ede.tar.gz",
+            .hash = "1220f6fd467fd42cd5ec98a360caacdcda9d3b9c3557fdcdef285cabbdee3c7c79dc",
         },
     },
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -45,10 +45,10 @@ fn idx_shuffle(allocator: Allocator, rand: Random, data: anytype, comptime IdxT:
     var intermediate = try allocator.alloc(IdxT, data.len);
     defer allocator.free(intermediate);
     for (intermediate, 0..) |*x, i|
-        x.* = @intCast(IdxT, i);
+        x.* = @intCast(i);
     rand.shuffle(IdxT, intermediate);
     for (rtn, 0..) |*x, i|
-        x.* = data[@intCast(usize, intermediate[i])];
+        x.* = data[@intCast(intermediate[i])];
     return rtn;
 }
 


### PR DESCRIPTION
Fix build when using Zig 0.11.0

### Todo

 - [x] Wait for https://github.com/hmusgrave/zkwargs/pull/1 to merge
 - [x] Update `zkwargs` dependency in `build.zig.zon`