### PR TITLE
Use `const` since local variable is never mutated

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -6,8 +6,8 @@
     },
     .dependencies = .{
         .zkwargs = .{
-            .url = "https://github.com/hmusgrave/zkwargs/archive/4b23becf731ecaac1f29d629943d11b23c7802e8.tar.gz",
-            .hash = "1220f6fd467fd42cd5ec98a360caacdcda9d3b9c3557fdcdef285cabbdee3c7c79dc",
+            .url = "https://github.com/hmusgrave/zkwargs/archive/f73c42cedcfc14a84d44d8f79cfd92e3f60d2a31.tar.gz",
+            .hash = "1220398c2b04b8d5320a97868cc017776216f1910889b6b2413853044eb5d6057238",
         },
     },
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,7 +2,7 @@
     .name = "zshuffle",
     .version = "0.0.0",
     .paths = .{
-        ".",
+        "",
     },
     .dependencies = .{
         .zkwargs = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,9 @@
 .{
     .name = "zshuffle",
     .version = "0.0.0",
+    .paths = .{
+        ".",
+    },
     .dependencies = .{
         .zkwargs = .{
             .url = "https://github.com/hmusgrave/zkwargs/archive/4b23becf731ecaac1f29d629943d11b23c7802e8.tar.gz",

--- a/src/main.zig
+++ b/src/main.zig
@@ -32,7 +32,7 @@ pub fn shuffle(rand: Random, data: anytype, _kwargs: anytype) ShuffleRtnT(@TypeO
 }
 
 fn copy_shuffle(allocator: Allocator, rand: Random, data: anytype) ![]@TypeOf(data[0]) {
-    var rtn = try allocator.alloc(@TypeOf(data[0]), data.len);
+    const rtn = try allocator.alloc(@TypeOf(data[0]), data.len);
     for (rtn, 0..) |*x, i|
         x.* = data[i];
     rand.shuffle(@TypeOf(data[0]), rtn);
@@ -40,9 +40,9 @@ fn copy_shuffle(allocator: Allocator, rand: Random, data: anytype) ![]@TypeOf(da
 }
 
 fn idx_shuffle(allocator: Allocator, rand: Random, data: anytype, comptime IdxT: type) ![]@TypeOf(data[0]) {
-    var rtn = try allocator.alloc(@TypeOf(data[0]), data.len);
+    const rtn = try allocator.alloc(@TypeOf(data[0]), data.len);
     errdefer allocator.free(rtn);
-    var intermediate = try allocator.alloc(IdxT, data.len);
+    const intermediate = try allocator.alloc(IdxT, data.len);
     defer allocator.free(intermediate);
     for (intermediate, 0..) |*x, i|
         x.* = @intCast(i);
@@ -89,8 +89,8 @@ test "doesn't crash" {
     std.debug.print("\n", .{});
     const allocator = std.testing.allocator;
     var ri = DefaultPrng.init(42);
-    var rand = ri.random();
-    var data = try allocator.alloc(f64, 10000);
+    const rand = ri.random();
+    const data = try allocator.alloc(f64, 10000);
     defer allocator.free(data);
     shuffle(rand, data, .{});
     allocator.free(try shuffle(rand, data, .{ .allocator = allocator }));


### PR DESCRIPTION
Use `const` since local variable is never mutated

Spotted while trying this project out with the latest Zig `master` (`0.12.0-dev.1676+40b8c993f`)

```
src/main.zig:35:9: error: local variable is never mutated
    var rtn = try allocator.alloc(@TypeOf(data[0]), data.len);
        ^~~
src/main.zig:35:9: note: consider using 'const'
src/main.zig:45:9: error: local variable is never mutated
    var intermediate = try allocator.alloc(IdxT, data.len);
        ^~~~~~~~~~~~
src/main.zig:45:9: note: consider using 'const'
src/main.zig:43:9: error: local variable is never mutated
    var rtn = try allocator.alloc(@TypeOf(data[0]), data.len);
        ^~~
src/main.zig:43:9: note: consider using 'const'
src/main.zig:93:9: error: local variable is never mutated
    var data = try allocator.alloc(f64, 10000);
        ^~~~
src/main.zig:93:9: note: consider using 'const'
src/main.zig:92:9: error: local variable is never mutated
    var rand = ri.random();
        ^~~~
```


### Todo

 - [x] Wait for https://github.com/hmusgrave/zkwargs/pull/2 to be merged and update the `zkwargs` dependency in this project